### PR TITLE
Add partial information utilities and Python bindings

### DIFF
--- a/python/example_state.json
+++ b/python/example_state.json
@@ -1,0 +1,13 @@
+{
+  "columns": [
+    {"hidden": ["unknown"], "visible": ["AS"]},
+    {"hidden": ["unknown", "unknown"], "visible": ["2D"]},
+    {"hidden": [], "visible": ["3C"]},
+    {"hidden": [], "visible": ["4H"]},
+    {"hidden": [], "visible": ["5S"]},
+    {"hidden": [], "visible": ["6D"]},
+    {"hidden": [], "visible": ["7C"]}
+  ],
+  "deck": ["unknown"],
+  "draw_step": 1
+}

--- a/python/lonelybot_py/Cargo.toml
+++ b/python/lonelybot_py/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lonelybot_py"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "lonelybot_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+lonelybot = { path = "../.." }
+pyo3 = { version = "0.21", features = ["extension-module"] }
+

--- a/python/lonelybot_py/src/lib.rs
+++ b/python/lonelybot_py/src/lib.rs
@@ -1,0 +1,45 @@
+use lonelybot::analysis::{ranked_moves, HeuristicConfig, PlayStyle};
+use lonelybot::engine::SolitaireEngine;
+use lonelybot::pruning::FullPruner;
+use lonelybot::standard::StandardSolitaire;
+use pyo3::prelude::*;
+
+#[pyclass]
+#[derive(Clone)]
+struct GameState {
+    inner: StandardSolitaire,
+}
+
+#[pymethods]
+impl GameState {
+    #[new]
+    fn new() -> Self {
+        use lonelybot::shuffler::default_shuffle;
+        use core::num::NonZeroU8;
+        let deck = default_shuffle(0);
+        Self { inner: StandardSolitaire::new(&deck, NonZeroU8::new(1).unwrap()) }
+    }
+}
+
+#[pyfunction]
+fn py_ranked_moves(state: &GameState, style: &str) -> PyResult<Vec<(String, i32)>> {
+    let style = match style {
+        "aggressive" => PlayStyle::Aggressive,
+        "conservative" => PlayStyle::Conservative,
+        _ => PlayStyle::Neutral,
+    };
+    let mut engine: SolitaireEngine<FullPruner> = state.inner.clone().into();
+    let moves = ranked_moves(&engine, style, &HeuristicConfig::default());
+    Ok(moves
+        .into_iter()
+        .map(|m| (m.mv.to_string(), m.heuristic_score))
+        .collect())
+}
+
+#[pymodule]
+fn lonelybot_py(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<GameState>()?;
+    m.add_function(wrap_pyfunction!(py_ranked_moves, m)?)?;
+    Ok(())
+}
+

--- a/python/main.py
+++ b/python/main.py
@@ -1,0 +1,32 @@
+"""Lonelybot interactive CLI"""
+import json
+from lonelybot_py import GameState, py_ranked_moves
+
+
+def main():
+    game = GameState()
+    while True:
+        cmd = input("lonelybot> ").strip()
+        if cmd == "quit":
+            break
+        if cmd == "best":
+            moves = py_ranked_moves(game, "neutral")
+            if moves:
+                print(moves[0])
+            continue
+        if cmd == "prob":
+            print("probability feature not implemented in python stub")
+            continue
+        if cmd.startswith("custom"):
+            _, path = cmd.split(maxsplit=1)
+            with open(path) as f:
+                state = json.load(f)
+            print("loaded", state)
+            continue
+        if cmd == "help":
+            print("commands: best, prob, custom <file>, quit")
+            continue
+
+
+if __name__ == "__main__":
+    main()

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,0 +1,99 @@
+//! Heuristic evaluation and move ranking utilities.
+//!
+//! This module provides a very small set of expert inspired heuristics and
+//! facilities to rank legal moves of a game state.
+
+use crate::engine::SolitaireEngine;
+use crate::moves::Move;
+use crate::pruning::FullPruner;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+/// Player style used to influence the evaluation of moves.
+#[derive(Clone, Copy, Debug)]
+pub enum PlayStyle {
+    Conservative,
+    Neutral,
+    Aggressive,
+}
+
+/// Weights for the different heuristics used during evaluation.
+#[derive(Clone, Debug)]
+pub struct HeuristicConfig {
+    pub reveal_bonus: i32,
+    pub empty_column_bonus: i32,
+    pub early_foundation_penalty: i32,
+    pub keep_king_bonus: i32,
+    pub deadlock_penalty: i32,
+}
+
+impl Default for HeuristicConfig {
+    fn default() -> Self {
+        Self {
+            reveal_bonus: 5,
+            empty_column_bonus: 2,
+            early_foundation_penalty: -3,
+            keep_king_bonus: 1,
+            deadlock_penalty: -10,
+        }
+    }
+}
+
+/// Result of a ranked move.
+#[derive(Clone, Debug)]
+pub struct RankedMove {
+    pub mv: Move,
+    pub heuristic_score: i32,
+    pub simulation_score: i32,
+    pub will_block: bool,
+}
+
+/// Evaluate a move using very small heuristics.
+fn evaluate_move(style: PlayStyle, engine: &SolitaireEngine<FullPruner>, m: Move, cfg: &HeuristicConfig) -> i32 {
+    let mut score = 0;
+    match m {
+        Move::Reveal(_) => score += cfg.reveal_bonus,
+        Move::PileStack(c) => {
+            if c.rank() < 5 {
+                score += cfg.early_foundation_penalty;
+            }
+        }
+        Move::DeckPile(c) | Move::StackPile(c) => {
+            if c.is_king() && engine.state().get_hidden().len(6) == 0 {
+                score += cfg.keep_king_bonus;
+            }
+        }
+        _ => {}
+    }
+
+    // style modifier
+    score += match style {
+        PlayStyle::Aggressive => 1,
+        PlayStyle::Conservative => -1,
+        PlayStyle::Neutral => 0,
+    };
+    score
+}
+
+/// Return a sorted list of legal moves with heuristic scores.
+#[must_use]
+pub fn ranked_moves(
+    engine: &SolitaireEngine<FullPruner>,
+    style: PlayStyle,
+    cfg: &HeuristicConfig,
+) -> Vec<RankedMove> {
+    let moves = engine.list_moves_dom();
+    let mut res: Vec<RankedMove> = moves
+        .iter()
+        .map(|&m| RankedMove {
+            mv: m,
+            heuristic_score: evaluate_move(style, engine, m, cfg),
+            simulation_score: 0,
+            will_block: false,
+        })
+        .collect();
+    res.sort_by_key(|m| -m.heuristic_score);
+    res
+}
+

--- a/src/game_theory.rs
+++ b/src/game_theory.rs
@@ -1,0 +1,54 @@
+//! Simplified MCTS based move selection working on partial information.
+
+use rand::prelude::*;
+
+use crate::analysis::{ranked_moves, HeuristicConfig, PlayStyle, RankedMove};
+use crate::engine::SolitaireEngine;
+use crate::pruning::FullPruner;
+
+/// Run a light Monte Carlo tree search to pick the best move.
+#[must_use]
+pub fn best_move_mcts<R: Rng>(
+    engine: &mut SolitaireEngine<FullPruner>,
+    style: PlayStyle,
+    rng: &mut R,
+) -> Option<RankedMove> {
+    let cfg = HeuristicConfig::default();
+    let moves = ranked_moves(engine, style, &cfg);
+    // perform a very small random playout for each move
+    let mut best: Option<(RankedMove, i32)> = None;
+    for m in moves {
+        let mut child: SolitaireEngine<FullPruner> = engine.state().clone().into();
+        child.do_move(m.mv);
+        let mut score = 0;
+        for _ in 0..3 {
+            let mut tmp: SolitaireEngine<FullPruner> = child.state().clone().into();
+            let mut depth = 0;
+            while depth < 10 {
+                let mv = {
+                    let list = tmp.list_moves_dom();
+                    if list.is_empty() {
+                        break;
+                    }
+                    *list.choose(rng).unwrap()
+                };
+                tmp.do_move(mv);
+                depth += 1;
+                if tmp.state().is_win() {
+                    score += 10;
+                    break;
+                }
+            }
+        }
+        if let Some((_, best_score)) = &mut best {
+            if score > *best_score {
+                *best_score = score;
+                best = Some((m.clone(), score));
+            }
+        } else {
+            best = Some((m.clone(), score));
+        }
+    }
+    best.map(|b| b.0)
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,7 @@ pub mod state;
 pub mod tracking;
 pub mod traverse;
 pub mod dependencies;
+pub mod partial;
+pub mod analysis;
+pub mod game_theory;
 mod utils;

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1,0 +1,146 @@
+//! Partial information state support for Klondike
+//!
+//! This module allows representing hidden cards as `Option<Card>` and provides
+//! helpers for filling unknown cards randomly as well as computing simple
+//! probability estimates for hidden columns.
+
+use rand::seq::SliceRandom;
+use rand::Rng;
+
+use crate::card::{Card, N_CARDS};
+use crate::shuffler::CardDeck;
+use crate::standard::{PileVec, StandardSolitaire};
+
+extern crate alloc;
+use alloc::vec::Vec;
+use alloc::collections::BTreeSet;
+
+/// Representation of a single tableau column with partially known cards.
+#[derive(Clone, Debug)]
+pub struct PartialColumn {
+    /// Hidden cards from top to bottom. `None` represents an unknown card.
+    pub hidden: Vec<Option<Card>>,
+    /// Visible cards from bottom to top.
+    pub visible: PileVec,
+}
+
+impl PartialColumn {
+    /// Number of hidden cards.
+    #[must_use]
+    pub fn hidden_len(&self) -> usize {
+        self.hidden.iter().filter(|c| c.is_none()).count()
+    }
+}
+
+/// Representation of a partial Klondike state.
+#[derive(Clone, Debug)]
+pub struct PartialState {
+    pub columns: [PartialColumn; 7],
+    pub deck: Vec<Option<Card>>, // top of deck is the end of the vec
+    pub draw_step: u8,
+}
+
+impl PartialState {
+    /// Fill the unknown cards using a random permutation of the remaining
+    /// cards. The returned `StandardSolitaire` can then be solved using the
+    /// existing engine.
+    #[must_use]
+    pub fn fill_unknowns_randomly<R: Rng>(&self, rng: &mut R) -> StandardSolitaire {
+        let mut used = BTreeSet::new();
+        for col in &self.columns {
+            for c in &col.visible {
+                used.insert(c.mask_index());
+            }
+            for c in &col.hidden {
+                if let Some(card) = c {
+                    used.insert(card.mask_index());
+                }
+            }
+        }
+        for c in &self.deck {
+            if let Some(card) = c {
+                used.insert(card.mask_index());
+            }
+        }
+
+        let mut remaining: Vec<Card> = (0..N_CARDS)
+            .filter(|i| !used.contains(i))
+            .map(Card::from_mask_index)
+            .collect();
+        remaining.shuffle(rng);
+        let mut rem_iter = remaining.into_iter();
+
+        // Build the card deck in the format expected by StandardSolitaire
+        let mut cards = Vec::with_capacity(N_CARDS as usize);
+        for col in &self.columns {
+            for h in &col.hidden {
+                if let Some(c) = h {
+                    cards.push(*c);
+                } else {
+                    cards.push(rem_iter.next().unwrap());
+                }
+            }
+            for &v in &col.visible {
+                cards.push(v);
+            }
+        }
+        for c in &self.deck {
+            if let Some(card) = c.clone() {
+                cards.push(card);
+            } else {
+                cards.push(rem_iter.next().unwrap());
+            }
+        }
+        while cards.len() < N_CARDS as usize {
+            cards.push(rem_iter.next().unwrap());
+        }
+        let mut array: CardDeck = [Card::DEFAULT; N_CARDS as usize];
+        array.copy_from_slice(&cards);
+        use core::num::NonZeroU8;
+        StandardSolitaire::new(&array, NonZeroU8::new(self.draw_step).unwrap())
+    }
+
+    /// Compute simplistic probability estimates for every hidden column.
+    #[must_use]
+    pub fn column_probabilities(&self) -> Vec<Vec<(Card, f64)>> {
+        let mut used = BTreeSet::new();
+        let mut total_unknown = 0usize;
+        for col in &self.columns {
+            for c in &col.visible {
+                used.insert(c.mask_index());
+            }
+            for c in &col.hidden {
+                match c {
+                    Some(card) => {
+                        used.insert(card.mask_index());
+                    }
+                    None => total_unknown += 1,
+                }
+            }
+        }
+        for c in &self.deck {
+            if let Some(card) = c {
+                used.insert(card.mask_index());
+            } else {
+                total_unknown += 1;
+            }
+        }
+        let remaining: Vec<Card> = (0..N_CARDS)
+            .filter(|i| !used.contains(i))
+            .map(Card::from_mask_index)
+            .collect();
+        let n_remaining = remaining.len() as f64;
+        let mut res = Vec::new();
+        for col in &self.columns {
+            let n_unknown = col.hidden.iter().filter(|c| c.is_none()).count();
+            let prob = if total_unknown == 0 {
+                0.0
+            } else {
+                n_unknown as f64 / total_unknown as f64
+            };
+            res.push(remaining.iter().map(|&c| (c, prob / n_remaining)).collect());
+        }
+        res
+    }
+}
+

--- a/tests/partial.rs
+++ b/tests/partial.rs
@@ -1,0 +1,18 @@
+use lonelybot::partial::{PartialColumn, PartialState};
+use lonelybot::card::Card;
+use lonelybot::standard::PileVec;
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+
+#[test]
+fn test_fill_unknown() {
+    let col = PartialColumn { hidden: vec![None], visible: {
+        let mut p = PileVec::new();
+        p.push(Card::new(0,0));
+        p
+    }};
+    let state = PartialState { columns: [col.clone(), col.clone(), col.clone(), col.clone(), col.clone(), col.clone(), col], deck: vec![None], draw_step: 1 };
+    let mut rng = SmallRng::seed_from_u64(0);
+    let g = state.fill_unknowns_randomly(&mut rng);
+    assert_eq!(g.get_deck().len(), 24);
+}


### PR DESCRIPTION
## Summary
- add `PartialState` model for unknown cards with random filler
- implement simple heuristics and move ranking
- provide a lightweight MCTS helper
- expose minimal PyO3 bindings and example CLI
- include tests for partial state handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68649e6fc5dc8332b1ea75f76ae38b08