### PR TITLE
Add partial state analysis and Python bindings

### DIFF
--- a/python/lonelybot_py/pyproject.toml
+++ b/python/lonelybot_py/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["maturin>=1.3"]
+build-backend = "maturin"
+
+[project]
+name = "lonelybot_py"
+version = "0.1.0"
+requires-python = ">=3.8"

--- a/python/main.py
+++ b/python/main.py
@@ -1,6 +1,7 @@
 """Lonelybot interactive CLI"""
 import json
-from lonelybot_py import GameState, py_ranked_moves
+from lonelybot_py import GameState, ranked_moves_py
+from utils import parse_hidden
 
 
 def main():
@@ -10,7 +11,7 @@ def main():
         if cmd == "quit":
             break
         if cmd == "best":
-            moves = py_ranked_moves(game, "neutral")
+            moves = ranked_moves_py(game, "neutral")
             if moves:
                 print(moves[0])
             continue
@@ -20,8 +21,14 @@ def main():
         if cmd.startswith("custom"):
             _, path = cmd.split(maxsplit=1)
             with open(path) as f:
-                state = json.load(f)
-            print("loaded", state)
+                data = json.load(f)
+            if "columns" in data:
+                for col in data["columns"]:
+                    col["hidden"] = parse_hidden(col.get("hidden", []))
+            if "deck" in data:
+                data["deck"] = parse_hidden(data["deck"])
+            game = GameState.from_json(json.dumps(data))
+            print("loaded", path)
             continue
         if cmd == "help":
             print("commands: best, prob, custom <file>, quit")

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,0 +1,20 @@
+"""Utility helpers for JSON loading."""
+
+from typing import List, Optional
+
+RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
+SUITS = ["H", "D", "C", "S"]
+
+
+def parse_hidden(values: List):
+    """Convert JSON values to optional card strings.
+
+    ``"unknown"`` or ``-1`` are translated to ``None``.
+    """
+    result: List[Optional[str]] = []
+    for v in values:
+        if v == "unknown" or v == -1:
+            result.append(None)
+        else:
+            result.append(str(v))
+    return result

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -40,6 +40,21 @@ pub struct PartialState {
     pub draw_step: u8,
 }
 
+impl From<&StandardSolitaire> for PartialState {
+    fn from(g: &StandardSolitaire) -> Self {
+        let columns: [PartialColumn; 7] = core::array::from_fn(|i| PartialColumn {
+            hidden: g.get_hidden()[i].iter().map(|&c| Some(c)).collect(),
+            visible: g.get_piles()[i].clone(),
+        });
+        let deck: Vec<Option<Card>> = g.get_deck().iter().map(Some).collect();
+        Self {
+            columns,
+            deck,
+            draw_step: g.get_deck().draw_step().get(),
+        }
+    }
+}
+
 impl PartialState {
     /// Fill the unknown cards using a random permutation of the remaining
     /// cards. The returned `StandardSolitaire` can then be solved using the

--- a/tests/partial.rs
+++ b/tests/partial.rs
@@ -3,6 +3,7 @@ use lonelybot::card::Card;
 use lonelybot::standard::PileVec;
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
+use lonelybot::analysis::analyze_state;
 
 #[test]
 fn test_fill_unknown() {
@@ -15,4 +16,17 @@ fn test_fill_unknown() {
     let mut rng = SmallRng::seed_from_u64(0);
     let g = state.fill_unknowns_randomly(&mut rng);
     assert_eq!(g.get_deck().len(), 24);
+}
+
+#[test]
+fn test_analyze_state() {
+    let col = PartialColumn { hidden: vec![None], visible: {
+        let mut p = PileVec::new();
+        p.push(Card::new(0,0));
+        p
+    }};
+    let state = PartialState { columns: [col.clone(), col.clone(), col.clone(), col.clone(), col.clone(), col.clone(), col], deck: vec![None], draw_step: 1 };
+    let info = analyze_state(&state);
+    assert_eq!(info.unknown_cards, 8);
+    assert!(info.mobility > 0);
 }


### PR DESCRIPTION
## Summary
- implement `StateAnalysis` and `analyze_state` for partial states
- expose new Python bindings with MCTS search and utilities
- allow JSON loading with unknown cards and provide helper
- include simple CLI support
- add tests for the new analysis feature

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6864a29d2f748332a084338826720d8a