### PR TITLE
Expose heuristic config in python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ This installs a `lonelybot_py` module providing `GameState`, `Move`,
 `analyze_state`.  The helper `python/utils.py` includes a `parse_hidden()`
 function for loading JSON states with `"unknown"` or `-1` values.
 
+Heuristic weights can be customised through the `HeuristicConfig` class and
+passed to `ranked_moves`, `best_move` or `best_move_mcts`:
+
+```python
+from lonelybot_py import GameState, HeuristicConfigPy, ranked_moves_py
+cfg = HeuristicConfigPy(reveal_bonus=10)
+print(ranked_moves_py(GameState(), "neutral", cfg)[0])
+```
+
 ## Seed
 There are 7 seed types
 - ``default``: using Rust rng

--- a/src/game_theory.rs
+++ b/src/game_theory.rs
@@ -11,10 +11,10 @@ use crate::pruning::FullPruner;
 pub fn best_move_mcts<R: Rng>(
     engine: &mut SolitaireEngine<FullPruner>,
     style: PlayStyle,
+    cfg: &HeuristicConfig,
     rng: &mut R,
 ) -> Option<RankedMove> {
-    let cfg = HeuristicConfig::default();
-    let moves = ranked_moves(engine, style, &cfg);
+    let moves = ranked_moves(engine, style, cfg);
     // perform a very small random playout for each move
     let mut best: Option<(RankedMove, i32)> = None;
     for m in moves {


### PR DESCRIPTION
## Summary
- add `HeuristicConfigPy` to Python API
- allow ranked_moves, best_move and best_move_mcts to receive an optional heuristic configuration
- expose the config in the interactive CLI
- document heuristic customization in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68691776ee588332a1ae93160530df6a