### PR TITLE
Adapt MCTS to partial states

### DIFF
--- a/python/lonelybot_py/src/lib.rs
+++ b/python/lonelybot_py/src/lib.rs
@@ -185,10 +185,8 @@ fn best_move_mcts_py(
     cfg: Option<&HeuristicConfigPy>,
 ) -> PyResult<Option<MovePy>> {
     let mut rng = SmallRng::seed_from_u64(0);
-    let mut g = state.state.fill_unknowns_randomly(&mut rng);
-    let mut engine: SolitaireEngine<FullPruner> = g.into();
     let cfg = cfg.map_or_else(HeuristicConfig::default, |c| c.into());
-    let mv = best_move_mcts(&mut engine, get_style(style), &cfg, &mut rng);
+    let mv = best_move_mcts(&state.state, get_style(style), &cfg, &mut rng);
     Ok(mv.map(|m| MovePy{mv:m.mv}))
 }
 

--- a/src/game_theory.rs
+++ b/src/game_theory.rs
@@ -4,49 +4,61 @@ use rand::prelude::*;
 
 use crate::analysis::{ranked_moves, HeuristicConfig, PlayStyle, RankedMove};
 use crate::engine::SolitaireEngine;
+use crate::partial::PartialState;
 use crate::pruning::FullPruner;
 
 /// Run a light Monte Carlo tree search to pick the best move.
 #[must_use]
 pub fn best_move_mcts<R: Rng>(
-    engine: &mut SolitaireEngine<FullPruner>,
+    state: &PartialState,
     style: PlayStyle,
     cfg: &HeuristicConfig,
     rng: &mut R,
 ) -> Option<RankedMove> {
-    let moves = ranked_moves(engine, style, cfg);
-    // perform a very small random playout for each move
-    let mut best: Option<(RankedMove, i32)> = None;
+    let filled = state.fill_unknowns_randomly(rng);
+    let solitaire: crate::state::Solitaire = (&filled).into();
+    let engine: SolitaireEngine<FullPruner> = solitaire.into();
+    let moves = ranked_moves(&engine, style, cfg);
+
+    let probs = state.column_probabilities();
+    let mut best: Option<(RankedMove, f64)> = None;
     for m in moves {
-        let mut child: SolitaireEngine<FullPruner> = engine.state().clone().into();
-        child.do_move(m.mv);
-        let mut score = 0;
+        let mut total = 0f64;
         for _ in 0..3 {
-            let mut tmp: SolitaireEngine<FullPruner> = child.state().clone().into();
-            let mut depth = 0;
-            while depth < 10 {
-                let mv = {
-                    let list = tmp.list_moves_dom();
-                    if list.is_empty() {
+            let filled = state.fill_unknowns_weighted(&probs, rng);
+            let solitaire_child: crate::state::Solitaire = (&filled).into();
+            let mut child: SolitaireEngine<FullPruner> = solitaire_child.into();
+            child.do_move(m.mv);
+            let mut score = 0;
+            for _ in 0..3 {
+                let mut tmp: SolitaireEngine<FullPruner> = child.state().clone().into();
+                let mut depth = 0;
+                while depth < 10 {
+                    let mv = {
+                        let list = tmp.list_moves_dom();
+                        if list.is_empty() {
+                            break;
+                        }
+                        *list.choose(rng).unwrap()
+                    };
+                    tmp.do_move(mv);
+                    depth += 1;
+                    if tmp.state().is_win() {
+                        score += 10;
                         break;
                     }
-                    *list.choose(rng).unwrap()
-                };
-                tmp.do_move(mv);
-                depth += 1;
-                if tmp.state().is_win() {
-                    score += 10;
-                    break;
                 }
             }
+            total += score as f64;
         }
-        if let Some((_, best_score)) = &mut best {
-            if score > *best_score {
-                *best_score = score;
-                best = Some((m.clone(), score));
+        let avg = total / 3.0;
+        if let Some((_, ref mut best_score)) = best {
+            if avg > *best_score {
+                *best_score = avg;
+                best = Some((m.clone(), avg));
             }
         } else {
-            best = Some((m.clone(), score));
+            best = Some((m.clone(), avg));
         }
     }
     best.map(|b| b.0)


### PR DESCRIPTION
## Summary
- allow MCTS solver to operate directly on a `PartialState`
- add helper for filling unknown cards according to probability estimates
- expose new behaviour to Python bindings

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68691cb97270833295425639cc45b57d