### PR TITLE
Add style coefficients for heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ from lonelybot_py import GameState, HeuristicConfigPy, ranked_moves_py
 cfg = HeuristicConfigPy(reveal_bonus=10)
 print(ranked_moves_py(GameState(), "neutral", cfg)[0])
 ```
+Style profiles can also be tuned with `aggressive_coef`, `conservative_coef` and
+`neutral_coef` fields in `HeuristicConfigPy`.
 
 ## Seed
 There are 7 seed types

--- a/python/lonelybot_py/src/lib.rs
+++ b/python/lonelybot_py/src/lib.rs
@@ -38,6 +38,12 @@ pub struct HeuristicConfigPy {
     pub keep_king_bonus: i32,
     #[pyo3(get, set)]
     pub deadlock_penalty: i32,
+    #[pyo3(get, set)]
+    pub aggressive_coef: i32,
+    #[pyo3(get, set)]
+    pub conservative_coef: i32,
+    #[pyo3(get, set)]
+    pub neutral_coef: i32,
 }
 
 #[pymethods]
@@ -49,6 +55,9 @@ impl HeuristicConfigPy {
         early_foundation_penalty: Option<i32>,
         keep_king_bonus: Option<i32>,
         deadlock_penalty: Option<i32>,
+        aggressive_coef: Option<i32>,
+        conservative_coef: Option<i32>,
+        neutral_coef: Option<i32>,
     ) -> Self {
         let d = HeuristicConfig::default();
         Self {
@@ -57,6 +66,9 @@ impl HeuristicConfigPy {
             early_foundation_penalty: early_foundation_penalty.unwrap_or(d.early_foundation_penalty),
             keep_king_bonus: keep_king_bonus.unwrap_or(d.keep_king_bonus),
             deadlock_penalty: deadlock_penalty.unwrap_or(d.deadlock_penalty),
+            aggressive_coef: aggressive_coef.unwrap_or(d.aggressive_coef),
+            conservative_coef: conservative_coef.unwrap_or(d.conservative_coef),
+            neutral_coef: neutral_coef.unwrap_or(d.neutral_coef),
         }
     }
 }
@@ -69,6 +81,9 @@ impl From<&HeuristicConfigPy> for HeuristicConfig {
             early_foundation_penalty: p.early_foundation_penalty,
             keep_king_bonus: p.keep_king_bonus,
             deadlock_penalty: p.deadlock_penalty,
+            aggressive_coef: p.aggressive_coef,
+            conservative_coef: p.conservative_coef,
+            neutral_coef: p.neutral_coef,
         }
     }
 }

--- a/python/main.py
+++ b/python/main.py
@@ -12,7 +12,7 @@ from utils import parse_hidden
 def main():
     game = GameState()
     cfg = HeuristicConfigPy(
-        None, None, None, None, None
+        None, None, None, None, None, None, None, None
     )
     while True:
         cmd = input("lonelybot> ").strip()
@@ -52,6 +52,9 @@ def main():
                 weights.get("early_foundation_penalty"),
                 weights.get("keep_king_bonus"),
                 weights.get("deadlock_penalty"),
+                weights.get("aggressive_coef"),
+                weights.get("conservative_coef"),
+                weights.get("neutral_coef"),
             )
             print("heuristics loaded", path)
             continue


### PR DESCRIPTION
## Summary
- allow weighting heuristics per `PlayStyle`
- expose new fields in Python bindings and CLI script
- document custom style coefficients

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68691cb8637083329fe9bd434829345d