### PR TITLE
Use hidden-card probabilities in move evaluation

### DIFF
--- a/python/lonelybot_py/src/lib.rs
+++ b/python/lonelybot_py/src/lib.rs
@@ -160,7 +160,7 @@ fn ranked_moves_py(
     let g = state.state.fill_unknowns_randomly(&mut rng);
     let engine: SolitaireEngine<FullPruner> = g.into();
     let cfg = cfg.map_or_else(HeuristicConfig::default, |c| c.into());
-    let moves = ranked_moves(&engine, get_style(style), &cfg);
+    let moves = ranked_moves(&engine, &state.state, get_style(style), &cfg);
     Ok(moves.into_iter().map(|m| (MovePy{mv:m.mv}, m.heuristic_score)).collect())
 }
 
@@ -174,7 +174,9 @@ fn best_move_py(
     let g = state.state.fill_unknowns_randomly(&mut rng);
     let engine: SolitaireEngine<FullPruner> = g.into();
     let cfg = cfg.map_or_else(HeuristicConfig::default, |c| c.into());
-    let mv = ranked_moves(&engine, get_style(style), &cfg).into_iter().next();
+    let mv = ranked_moves(&engine, &state.state, get_style(style), &cfg)
+        .into_iter()
+        .next();
     Ok(mv.map(|m| MovePy{mv:m.mv}))
 }
 
@@ -188,7 +190,7 @@ fn best_move_mcts_py(
     let mut g = state.state.fill_unknowns_randomly(&mut rng);
     let mut engine: SolitaireEngine<FullPruner> = g.into();
     let cfg = cfg.map_or_else(HeuristicConfig::default, |c| c.into());
-    let mv = best_move_mcts(&mut engine, get_style(style), &cfg, &mut rng);
+    let mv = best_move_mcts(&mut engine, &state.state, get_style(style), &cfg, &mut rng);
     Ok(mv.map(|m| MovePy{mv:m.mv}))
 }
 

--- a/src/game_theory.rs
+++ b/src/game_theory.rs
@@ -3,6 +3,7 @@
 use rand::prelude::*;
 
 use crate::analysis::{ranked_moves, HeuristicConfig, PlayStyle, RankedMove};
+use crate::partial::PartialState;
 use crate::engine::SolitaireEngine;
 use crate::pruning::FullPruner;
 
@@ -10,11 +11,12 @@ use crate::pruning::FullPruner;
 #[must_use]
 pub fn best_move_mcts<R: Rng>(
     engine: &mut SolitaireEngine<FullPruner>,
+    state: &PartialState,
     style: PlayStyle,
     cfg: &HeuristicConfig,
     rng: &mut R,
 ) -> Option<RankedMove> {
-    let moves = ranked_moves(engine, style, cfg);
+    let moves = ranked_moves(engine, state, style, cfg);
     // perform a very small random playout for each move
     let mut best: Option<(RankedMove, i32)> = None;
     for m in moves {


### PR DESCRIPTION
## Summary
- factor in `PartialState::column_probabilities` while evaluating moves
- weight reveal moves using their probability of success
- pass partial state to `ranked_moves` and MCTS helpers
- update Python bindings for new APIs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68691cb6a5b08332b683f95ed774d77f