### PR TITLE
Add deadlock penalty heuristic

### DIFF
--- a/src/game_theory.rs
+++ b/src/game_theory.rs
@@ -3,7 +3,6 @@
 use rand::prelude::*;
 
 use crate::analysis::{ranked_moves, HeuristicConfig, PlayStyle, RankedMove};
-use crate::partial::PartialState;
 use crate::engine::SolitaireEngine;
 use crate::partial::PartialState;
 use crate::pruning::FullPruner;
@@ -17,57 +16,16 @@ pub fn best_move_mcts<R: Rng>(
     cfg: &HeuristicConfig,
     rng: &mut R,
 ) -> Option<RankedMove> {
-let filled = state.fill_unknowns_randomly(rng);
-let solitaire: crate::state::Solitaire = (&filled).into();
-let engine: SolitaireEngine<FullPruner> = solitaire.into();
-let mut moves = ranked_moves(&engine, state, style, cfg);
+    let filled = state.fill_unknowns_randomly(rng);
+    let solitaire: crate::state::Solitaire = (&filled).into();
+    let engine: SolitaireEngine<FullPruner> = solitaire.into();
+    let mut moves = ranked_moves(&engine, state, style, cfg);
 
-let probs = state.column_probabilities();
-let mut best: Option<(RankedMove, f64)> = None;
+    let probs = state.column_probabilities();
+    let mut best: Option<(RankedMove, f64)> = None;
 
-for m in &mut moves {
-    let mut total = 0f64;
-
-    // Playouts pondérés
-    for _ in 0..3 {
-        let filled = state.fill_unknowns_weighted(&probs, rng);
-        let solitaire_child: crate::state::Solitaire = (&filled).into();
-        let mut child: SolitaireEngine<FullPruner> = solitaire_child.into();
-        child.do_move(m.mv);
-
-        let mut score = 0;
-        for _ in 0..3 {
-            let mut tmp: SolitaireEngine<FullPruner> = child.state().clone().into();
-            let mut depth = 0;
-            while depth < 10 {
-                let list = tmp.list_moves_dom();
-                if list.is_empty() {
-                    break;
-                }
-                let mv = *list.choose(rng).unwrap();
-                tmp.do_move(mv);
-                depth += 1;
-                if tmp.state().is_win() {
-                    score += 10;
-                    break;
-                }
-            }
-        }
-        total += score as f64;
-    }
-
-    let avg = total / 3.0;
-    if let Some((_, best_score)) = &mut best {
-        if avg > *best_score {
-            *best_score = avg;
-            best = Some((m.clone(), avg));
-        }
-    } else {
-        best = Some((m.clone(), avg));
-    }
-}
-
-best.map(|b| b.0)
+    for m in &mut moves {
+        let mut total = 0f64;
 
         for _ in 0..3 {
             let filled = state.fill_unknowns_weighted(&probs, rng);
@@ -76,19 +34,16 @@ best.map(|b| b.0)
             child.do_move(m.mv);
 
             let mut score = 0;
-
             for _ in 0..3 {
                 let mut tmp: SolitaireEngine<FullPruner> = child.state().clone().into();
                 let mut depth = 0;
 
                 while depth < 10 {
-                    let mv = {
-                        let list = tmp.list_moves_dom();
-                        if list.is_empty() {
-                            break;
-                        }
-                        *list.choose(rng).unwrap()
-                    };
+                    let list = tmp.list_moves_dom();
+                    if list.is_empty() {
+                        break;
+                    }
+                    let mv = *list.choose(rng).unwrap();
                     tmp.do_move(mv);
                     depth += 1;
 


### PR DESCRIPTION
## Summary
- account for deadlock risk in heuristic evaluations
- fix `game_theory` implementation to compile

## Testing
- `cargo check --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686940e4eb848332928abff60c4d16bd