### PR TITLE
Apply style coefficient after computing heuristic score

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ cfg = HeuristicConfigPy(reveal_bonus=10)
 print(ranked_moves_py(GameState(), "neutral", cfg)[0])
 ```
 Style profiles can also be tuned with `aggressive_coef`, `conservative_coef` and
-`neutral_coef` fields in `HeuristicConfigPy`.
+`neutral_coef` fields in `HeuristicConfigPy`. These coefficients multiply the
+final heuristic score for a move depending on the selected style.
 
 ## Seed
 There are 7 seed types

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -38,6 +38,8 @@ pub struct HeuristicConfig {
     pub deadlock_penalty: i32,
     pub long_column_bonus: i32,
     pub chain_bonus: i32,
+    /// Style coefficients multiply the final heuristic score based on the
+    /// selected play style.
     pub aggressive_coef: i32,
     pub conservative_coef: i32,
     pub neutral_coef: i32,
@@ -135,7 +137,7 @@ fn evaluate_move(
         }
         Move::PileStack(c) => {
             if c.rank() < 5 {
-                score += cfg.early_foundation_penalty * coeff;
+                score += cfg.early_foundation_penalty;
             }
             let col = hidden.find(c);
             let down = hidden.len(col).saturating_sub(1);
@@ -151,7 +153,7 @@ fn evaluate_move(
                 score += cfg.empty_column_bonus;
             }
             if c.is_king() && hidden.len(6) == 0 {
-                score += cfg.keep_king_bonus * coeff;
+                score += cfg.keep_king_bonus;
             }
         }
         _ => {}
@@ -195,7 +197,8 @@ fn evaluate_move(
 
     // round() may not be available in core for no_std; emulate simple rounding
 
-    ((score as f64) * prob + 0.5) as i32
+    let scaled = score * coeff;
+    ((scaled as f64) * prob + 0.5) as i32
 }
 
 fn count_empty_columns(game: &Solitaire) -> usize {

--- a/tests/style_coef.rs
+++ b/tests/style_coef.rs
@@ -1,0 +1,29 @@
+use lonelybot::analysis::{ranked_moves, HeuristicConfig, PlayStyle};
+use lonelybot::engine::SolitaireEngine;
+use lonelybot::pruning::FullPruner;
+use lonelybot::standard::StandardSolitaire;
+use lonelybot::shuffler::default_shuffle;
+use lonelybot::partial::PartialState;
+use std::num::NonZeroU8;
+
+#[test]
+fn test_style_coefficient_scales_total_score() {
+    let deck = default_shuffle(0);
+    let game = StandardSolitaire::new(&deck, NonZeroU8::new(3).unwrap());
+    let solitaire: lonelybot::state::Solitaire = (&game).into();
+    let engine: SolitaireEngine<FullPruner> = solitaire.into();
+    let state: PartialState = (&game).into();
+
+    let mut cfg1 = HeuristicConfig::default();
+    cfg1.neutral_coef = 1;
+    let moves1 = ranked_moves(&engine, &state, PlayStyle::Neutral, &cfg1);
+
+    let mut cfg2 = cfg1.clone();
+    cfg2.neutral_coef = 2;
+    let moves2 = ranked_moves(&engine, &state, PlayStyle::Neutral, &cfg2);
+
+    assert_eq!(moves1.len(), moves2.len());
+    for (a, b) in moves1.iter().zip(moves2.iter()) {
+        assert_eq!(b.heuristic_score, a.heuristic_score * 2);
+    }
+}


### PR DESCRIPTION
## Summary
- scale the entire heuristic score by the selected style coefficient
- document how style coefficients work
- add regression test for score scaling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686951a661088332b5c6db76dcde84aa