### PR TITLE
Expose blocking moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lonelybot
 - **Bayesian inference** using `column_probabilities` to estimate hidden cards.
 - **Strategic play styles** through the `PlayStyle` enum (`Conservative`, `Neutral`, `Aggressive`).
 - **Expert heuristics** configurable with `HeuristicConfig` and used in `ranked_moves` and Monte Carlo search.
-- **Ranked move output** with heuristic and simulation scores plus blocking status.
+- **Ranked move output** with heuristic and simulation scores and a `will_block` flag indicating if a move leaves no legal follow-up.
 - **State analysis** via `analyze_state` giving unknown count, remaining cards, mobility and deadlock risk.
 - **MCTS based solver** available through `best_move_mcts`.
 - **Partial JSON loading** where `"unknown"` or `-1` values denote hidden cards.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -234,11 +234,17 @@ pub fn ranked_moves(
 
             let heuristic_score = evaluate_move(style, engine, state, m, cfg);
 
+            // Determine if this move leaves the game with no legal follow-up
+            // moves. This information is surfaced so clients can avoid moves
+            // that dead-end the game state.
+            let tmp_engine: SolitaireEngine<FullPruner> = st.clone().into();
+            let will_block = tmp_engine.list_moves_dom().is_empty();
+
             RankedMove {
                 mv: m,
                 heuristic_score,
                 simulation_score: 0,
-                will_block: false,
+                will_block,
                 revealed_cards,
                 columns_freed,
                 win_rate: 0.0,


### PR DESCRIPTION
## Summary
- detect when a move would leave no legal follow-up moves
- surface this `will_block` flag in ranked moves
- document new flag in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686951ab18888332b2185acf5a392490