### PR TITLE
Fix Python CLI style option and weighted best move

### DIFF
--- a/python/lonelybot_py/src/lib.rs
+++ b/python/lonelybot_py/src/lib.rs
@@ -214,7 +214,8 @@ fn best_move_py(
     cfg: Option<&HeuristicConfigPy>,
 ) -> PyResult<Option<MovePy>> {
     let mut rng = SmallRng::seed_from_u64(0);
-    let g = state.state.fill_unknowns_randomly(&mut rng);
+    let probs = state.state.column_probabilities();
+    let g = state.state.fill_unknowns_weighted(&probs, &mut rng);
     let solitaire: lonelybot::state::Solitaire = (&g).into();
     let engine: SolitaireEngine<FullPruner> = solitaire.into();
     let cfg = cfg.map_or_else(HeuristicConfig::default, |c| c.into());

--- a/python/main.py
+++ b/python/main.py
@@ -11,6 +11,7 @@ from utils import parse_hidden
 
 def main():
     game = GameState()
+    style = "neutral"
     cfg = HeuristicConfigPy(
         None, None, None, None, None,
         None, None,  # long_column_bonus, chain_bonus
@@ -23,7 +24,7 @@ def main():
             break
 
         elif cmd == "best":
-            moves = ranked_moves_py(game, "neutral", cfg)
+            moves = ranked_moves_py(game, style, cfg)
             if moves:
                 print(moves[0])
             else:
@@ -99,9 +100,22 @@ def main():
             print(f"{name} set to {value}")
             continue
 
+        elif cmd.startswith("style"):
+            try:
+                _, st = cmd.split(maxsplit=1)
+            except ValueError:
+                print("Usage: style <aggressive|conservative|neutral>")
+                continue
+            if st not in ["aggressive", "conservative", "neutral"]:
+                print("Unknown style. Choose aggressive, conservative or neutral")
+                continue
+            style = st
+            print("style set to", style)
+            continue
+
         elif cmd == "help":
             print(
-                "commands: best, prob, custom <file>, weights <file>, set <field> <value>, quit"
+                "commands: best, prob, custom <file>, weights <file>, set <field> <value>, style <type>, quit"
             )
             continue
 


### PR DESCRIPTION
## Summary
- improve best_move_py to use weighted probabilities when filling unknown cards
- allow changing play style in the Python CLI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68695530cd108332a4e9b2cf61437a6a