### PR TITLE
Expose MCTS parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lonelybot
 - **Expert heuristics** configurable with `HeuristicConfig` and used in `ranked_moves` and Monte Carlo search.
 - **Ranked move output** with heuristic and simulation scores and a `will_block` flag indicating if a move leaves no legal follow-up.
 - **State analysis** via `analyze_state` giving unknown count, remaining cards, mobility and deadlock risk.
-- **MCTS based solver** available through `best_move_mcts`.
+- **MCTS based solver** available through `best_move_mcts` which now accepts `n_playouts` and `max_depth`.
 - **Partial JSON loading** where `"unknown"` or `-1` values denote hidden cards.
 - **Python bindings** exposing the above features for scripting.
 
@@ -55,6 +55,13 @@ passed to `ranked_moves`, `best_move` or `best_move_mcts`:
 from lonelybot_py import GameState, HeuristicConfigPy, ranked_moves_py
 cfg = HeuristicConfigPy(reveal_bonus=10)
 print(ranked_moves_py(GameState(), "neutral", cfg)[0])
+```
+`best_move_mcts` can be used similarly and takes the number of playouts and
+maximum search depth:
+
+```python
+from lonelybot_py import best_move_mcts_py
+print(best_move_mcts_py(GameState(), "neutral", cfg, 9, 10))
 ```
 Style profiles can also be tuned with `aggressive_coef`, `conservative_coef` and
 `neutral_coef` fields in `HeuristicConfigPy`. These coefficients multiply the

--- a/python/lonelybot_py/src/lib.rs
+++ b/python/lonelybot_py/src/lib.rs
@@ -230,10 +230,19 @@ fn best_move_mcts_py(
     state: &GameState,
     style: &str,
     cfg: Option<&HeuristicConfigPy>,
+    n_playouts: usize,
+    max_depth: usize,
 ) -> PyResult<Option<PyObject>> {
     let mut rng = SmallRng::seed_from_u64(0);
     let cfg = cfg.map_or_else(HeuristicConfig::default, |c| c.into());
-    let mv = best_move_mcts(&state.state, get_style(style), &cfg, &mut rng);
+    let mv = best_move_mcts(
+        &state.state,
+        get_style(style),
+        &cfg,
+        n_playouts,
+        max_depth,
+        &mut rng,
+    );
 
     Python::with_gil(|py| {
         Ok(mv.map(|m| {

--- a/python/main.py
+++ b/python/main.py
@@ -1,9 +1,21 @@
-"""Lonelybot interactive CLI"""
+"""Lonelybot interactive CLI.
+
+Commands include:
+    best        - heuristic best move
+    mcts <n> <d> - MCTS best move using ``n`` playouts and depth ``d``
+    prob        - show column probabilities
+    custom      - load a custom state
+    weights     - load heuristic weights
+    set         - set heuristic field
+    style       - choose style
+    quit        - exit
+"""
 import json
 from lonelybot_py import (
     GameState,
     HeuristicConfigPy,
     ranked_moves_py,
+    best_move_mcts_py,
     column_probabilities_py,
 )
 from utils import parse_hidden
@@ -27,6 +39,22 @@ def main():
             moves = ranked_moves_py(game, style, cfg)
             if moves:
                 print(moves[0])
+            else:
+                print("No moves available.")
+            continue
+
+        elif cmd.startswith("mcts"):
+            try:
+                _, n_playouts, depth = cmd.split(maxsplit=2)
+                n_playouts = int(n_playouts)
+                depth = int(depth)
+            except ValueError:
+                print("Usage: mcts <playouts> <max_depth>")
+                continue
+
+            mv = best_move_mcts_py(game, style, cfg, n_playouts, depth)
+            if mv:
+                print(mv)
             else:
                 print("No moves available.")
             continue
@@ -115,7 +143,7 @@ def main():
 
         elif cmd == "help":
             print(
-                "commands: best, prob, custom <file>, weights <file>, set <field> <value>, style <type>, quit"
+                "commands: best, mcts <playouts> <depth>, prob, custom <file>, weights <file>, set <field> <value>, style <type>, quit"
             )
             continue
 


### PR DESCRIPTION
## Summary
- add adjustable `n_playouts` and `max_depth` to `best_move_mcts`
- expose new arguments via Python bindings and CLI example
- document usage in README

## Testing
- `cargo test`
- `python3 -m py_compile python/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68695d9f0a34833291f718900a5f96e6