### PR TITLE
Handle zero weights in fill_unknowns_weighted

### DIFF
--- a/src/partial.rs
+++ b/src/partial.rs
@@ -161,15 +161,20 @@ impl PartialState {
                         })
                         .collect();
                     let sum: f64 = weights.iter().sum();
-                    let mut r = rng.gen::<f64>() * sum;
-                    let mut choose = 0usize;
-                    for (i, w) in weights.iter().enumerate() {
-                        if r <= *w {
-                            choose = i;
-                            break;
+                    let choose = if sum == 0.0 {
+                        rng.gen_range(0..remaining.len())
+                    } else {
+                        let mut r = rng.gen::<f64>() * sum;
+                        let mut c = 0usize;
+                        for (i, w) in weights.iter().enumerate() {
+                            if r <= *w {
+                                c = i;
+                                break;
+                            }
+                            r -= *w;
                         }
-                        r -= *w;
-                    }
+                        c
+                    };
                     cards.push(remaining.remove(choose));
                 }
             }

--- a/tests/partial.rs
+++ b/tests/partial.rs
@@ -30,3 +30,18 @@ fn test_analyze_state() {
     assert_eq!(info.unknown_cards, 8);
     assert!(info.mobility > 0);
 }
+
+#[test]
+fn test_fill_unknown_weighted_zero_sum() {
+    let col = PartialColumn { hidden: vec![None], visible: {
+        let mut p = PileVec::new();
+        p.push(Card::new(0,0));
+        p
+    }};
+    let state = PartialState { columns: [col.clone(), col.clone(), col.clone(), col.clone(), col.clone(), col.clone(), col], deck: vec![None], draw_step: 1 };
+    let probs: Vec<Vec<(Card, f64)>> = vec![Vec::new(); 7];
+    let mut rng = SmallRng::seed_from_u64(0);
+    let g = state.fill_unknowns_weighted(&probs, &mut rng);
+    let expected = Card::new(4, 1); // mask index 17 chosen by rng
+    assert_eq!(g.get_piles()[0][0], expected);
+}


### PR DESCRIPTION
## Summary
- handle zero-sum weights in `fill_unknowns_weighted`
- randomise card choice uniformly when column weights sum to zero
- add regression test for zero-weight case

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68695da7e6dc8332a55f893902492c40