### PR TITLE
Add training dataset generator

### DIFF
--- a/lonecli/Cargo.toml
+++ b/lonecli/Cargo.toml
@@ -18,6 +18,6 @@ signal-hook = "0.3.17"
 clap = { version = "4.5.3", features = ["std", "derive"] }
 lonelybot = { path = "../" }
 rand = { version = "0.9", default-features = false, features = ["small_rng"] }
+serde_json = "1.0.117"
 
 [dev-dependencies]
-serde_json = "1.0.117"

--- a/lonecli/src/main.rs
+++ b/lonecli/src/main.rs
@@ -2,6 +2,7 @@ mod solver;
 mod solvitaire;
 mod tracking;
 mod tui;
+mod training;
 
 use bpci::{Interval, NSuccessesSample, WilsonScore};
 use clap::{Args, Parser, Subcommand, ValueEnum};

--- a/lonecli/src/training.rs
+++ b/lonecli/src/training.rs
@@ -1,0 +1,82 @@
+use lonelybot::analysis::{ranked_moves, HeuristicConfig, PlayStyle};
+use lonelybot::engine::SolitaireEngine;
+use lonelybot::partial::PartialState;
+use lonelybot::pruning::FullPruner;
+use lonelybot::shuffler::default_shuffle;
+use lonelybot::standard::StandardSolitaire;
+use lonelybot::state::Solitaire;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use serde_json::{json, to_string, Value};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::num::NonZeroU8;
+
+fn state_to_json(state: &PartialState) -> Value {
+    let columns: Vec<Value> = state
+        .columns
+        .iter()
+        .map(|c| {
+            json!({
+                "hidden": c
+                    .hidden
+                    .iter()
+                    .map(|o| o.map(|x| x.to_string()).unwrap_or_else(|| "unknown".into()))
+                    .collect::<Vec<_>>(),
+                "visible": c
+                    .visible
+                    .iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    let deck: Vec<String> = state
+        .deck
+        .iter()
+        .map(|o| o.map(|x| x.to_string()).unwrap_or_else(|| "unknown".into()))
+        .collect();
+    json!({
+        "draw_step": state.draw_step,
+        "columns": columns,
+        "deck": deck,
+    })
+}
+
+pub fn collect_training_data(n_games: usize) -> std::io::Result<()> {
+    let file = File::create("training_data.jsonl")?;
+    let mut writer = BufWriter::new(file);
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    for i in 0..n_games {
+        let deck = default_shuffle(i as u64);
+        let std = StandardSolitaire::new(&deck, NonZeroU8::new(1).unwrap());
+        let solitaire: Solitaire = (&std).into();
+        let mut engine: SolitaireEngine<FullPruner> = solitaire.into();
+        let mut turn = 0usize;
+        while !engine.state().is_win() {
+            let state = PartialState::from(engine.state());
+            let moves = engine.list_moves_dom();
+            if moves.is_empty() {
+                break;
+            }
+            let ranked = ranked_moves(&engine, &state, PlayStyle::Neutral, &HeuristicConfig::default());
+            let mv = ranked.first().map(|m| m.mv).unwrap_or(moves[0]);
+            engine.do_move(mv);
+            let record = json!({
+                "turn": turn,
+                "partial_state": state_to_json(&state),
+                "available_moves": moves.iter().map(|m| m.to_string()).collect::<Vec<_>>(),
+                "selected_move": mv.to_string(),
+                "win": engine.state().is_win(),
+                "style": "neutral",
+            });
+            writer.write_all(to_string(&record)?.as_bytes())?;
+            writer.write_all(b"\n")?;
+            turn += 1;
+        }
+    }
+
+    writer.flush()
+}
+


### PR DESCRIPTION
## Summary
- implement `collect_training_data` for generating JSONL data
- expose new module in CLI
- add serde_json runtime dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c283ef2d883329acb78175c8ea6b8