### PR TITLE
Add training data collection interfaces

### DIFF
--- a/lonecli/Cargo.toml
+++ b/lonecli/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+path = "src/lib.rs"
+# default name is package name
+
 
 [[bin]]
 name = "lonecli"

--- a/lonecli/src/bin/collect.rs
+++ b/lonecli/src/bin/collect.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if let Err(e) = lonecli::training::collect_training_data(10_000_000) {
+        eprintln!("{e}");
+    }
+}

--- a/lonecli/src/lib.rs
+++ b/lonecli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod training;

--- a/lonecli/src/main.rs
+++ b/lonecli/src/main.rs
@@ -533,6 +533,11 @@ enum Commands {
         seed: StringSeed,
         draw_step: NonZeroU8,
     },
+    Collect {
+        /// Number of games to generate
+        #[arg(default_value_t = 1000)]
+        n_games: usize,
+    },
 }
 
 fn main() {
@@ -594,6 +599,11 @@ fn main() {
                     interval.upper(),
                     elapsed
                 );
+            }
+        }
+        Commands::Collect { n_games } => {
+            if let Err(e) = training::collect_training_data(*n_games) {
+                eprintln!("{e}");
             }
         }
     }

--- a/python/lonelybot_py/Cargo.toml
+++ b/python/lonelybot_py/Cargo.toml
@@ -12,6 +12,7 @@ lonelybot = { path = "../.." }
 pyo3 = { version = "0.21", features = ["extension-module"] }
 rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
 serde_json = "1"
+lonecli = { path = "../../lonecli" }
 
 [workspace]
 

--- a/python/lonelybot_py/src/lib.rs
+++ b/python/lonelybot_py/src/lib.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyValueError, PyIOError};
 use pyo3::wrap_pyfunction;
 use pyo3::Bound;
 
@@ -285,6 +285,12 @@ fn analyze_state_py(state: &GameState) -> PyResult<(usize, Vec<String>, usize, u
     ))
 }
 
+#[pyfunction]
+fn collect_training_data_py(n_games: usize) -> PyResult<()> {
+    lonecli::training::collect_training_data(n_games)
+        .map_err(|e| PyIOError::new_err(e.to_string()))
+}
+
 #[pymodule]
 fn lonelybot_py(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GameState>()?;
@@ -295,6 +301,7 @@ fn lonelybot_py(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(best_move_mcts_py, m)?)?;
     m.add_function(wrap_pyfunction!(column_probabilities_py, m)?)?;
     m.add_function(wrap_pyfunction!(analyze_state_py, m)?)?;
+    m.add_function(wrap_pyfunction!(collect_training_data_py, m)?)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- create a library target for `lonecli`
- add `collect` subcommand in CLI for generating simulated games
- provide standalone `collect` binary
- expose `collect_training_data_py` in Python bindings
- allow Python crate to depend on `lonecli`

## Testing
- `cargo test --quiet`
- `cargo check --quiet` in `python/lonelybot_py`

------
https://chatgpt.com/codex/tasks/task_e_686cbfc536f883329fd2cf25e2786a33