### PR TITLE
Expose mask index and package python helpers

### DIFF
--- a/python/lonelybot_py/lonelybot_py/__init__.py
+++ b/python/lonelybot_py/lonelybot_py/__init__.py
@@ -26,7 +26,7 @@ def step(state: GameState, move: str):
 
 def encode_observation(state: GameState) -> np.ndarray:
     data = _encode_observation(state)
-    return np.array(data, dtype=np.int32)
+    return np.array(data, dtype=np.int16)
 
 __all__ = [
     "GameState",

--- a/python/lonelybot_py/pyproject.toml
+++ b/python/lonelybot_py/pyproject.toml
@@ -6,3 +6,8 @@ build-backend = "maturin"
 name = "lonelybot_py"
 version = "0.1.0"
 requires-python = ">=3.8"
+
+[tool.maturin]
+python-source = "."
+packages = ["lonelybot_py"]
+module-name = "lonelybot_py.lonelybot_py"

--- a/src/card.rs
+++ b/src/card.rs
@@ -91,7 +91,7 @@ impl Card {
     }
 
     #[must_use]
-    pub(crate) const fn mask_index(self) -> u8 {
+    pub const fn mask_index(self) -> u8 {
         self.0
     }
 


### PR DESCRIPTION
## Summary
- make card::mask_index public
- expose Python helper package and ensure encoded observations use `np.int16`
- adjust pyproject to ship the Python helpers with the wheel

## Testing
- `maturin build --release`
- `python - <<'PY'
import numpy as np
from lonelybot_py import generate_random_state, step, legal_actions, is_terminal, encode_observation
s = generate_random_state()
assert encode_observation(s).dtype == np.int16
assert encode_observation(s).shape == (100,)
assert legal_actions(s)
s2, done, reward = step(s, legal_actions(s)[0])
assert s2 != s
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68700183d17c83328f074b5d54079db1