### PR TITLE
Add AlphaZero compatible Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Style profiles can also be tuned with `aggressive_coef`, `conservative_coef` and
 `neutral_coef` fields in `HeuristicConfigPy`. These coefficients multiply the
 final heuristic score for a move depending on the selected style.
 
+### AlphaZero helpers
+
+The bindings also expose convenience functions mirroring the `Game` interface of
+`AlphaZero-General`. They return NumPy arrays and compact action indices:
+
+```python
+from lonelybot_py import reset, get_valid_actions, step_action, get_game_result
+
+state, board = reset()
+valid = get_valid_actions(state)
+next_state, board, reward, done = step_action(state, valid[0])
+result = get_game_result(next_state)
+```
+
 ## Collecting Training Data
 
 The helper `collect_training_data` function generates self-play positions for

--- a/python/lonelybot_py/Cargo.toml
+++ b/python/lonelybot_py/Cargo.toml
@@ -13,6 +13,7 @@ pyo3 = { version = "0.21", features = ["extension-module"] }
 rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
 serde_json = "1"
 lonecli = { path = "../../lonecli" }
+numpy = "0.20"
 
 [workspace]
 

--- a/python/lonelybot_py/lonelybot_py/__init__.py
+++ b/python/lonelybot_py/lonelybot_py/__init__.py
@@ -15,6 +15,13 @@ from .lonelybot_py import (
     legal_actions_py as legal_actions,
     is_terminal_py as is_terminal,
     encode_observation_py as _encode_observation,
+    reset_py as _reset,
+    get_valid_actions_py as get_valid_actions,
+    step_action_py as _step_action,
+    get_game_result_py as get_game_result,
+    get_board_size_py as get_board_size,
+    get_action_size_py as get_action_size,
+    get_canonical_board_py as get_canonical_board,
 )
 
 import numpy as np
@@ -22,6 +29,16 @@ import numpy as np
 
 def step(state: GameState, move: str):
     return _step(state, move)
+
+
+def reset():
+    state, board = _reset()
+    return state, np.array(board, dtype=np.int8)
+
+
+def step_action(state: GameState, action: int):
+    next_state, board, reward, done = _step_action(state, action)
+    return next_state, np.array(board, dtype=np.int8), int(reward), bool(done)
 
 
 def encode_observation(state: GameState) -> np.ndarray:
@@ -40,7 +57,14 @@ __all__ = [
     "collect_training_data",
     "generate_random_state",
     "step",
+    "step_action",
+    "reset",
     "legal_actions",
     "is_terminal",
+    "get_valid_actions",
+    "get_game_result",
+    "get_board_size",
+    "get_action_size",
+    "get_canonical_board",
     "encode_observation",
 ]


### PR DESCRIPTION
## Summary
- expose numpy-based helpers for AlphaZero-General
- add action mapping utilities and board constants
- register new pyfunctions in the Python module
- provide python wrappers and example usage in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687158f477f48332a31dad5b6c029d31